### PR TITLE
Ignore PairTeX run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
 *.py[cod]
 .DS_Store
+
+# PairTeX run artifacts: feedback written into whatever project PairTeX targets,
+# including the bundled demos.
+.pairtex/


### PR DESCRIPTION
## What

Adds `.pairtex/` to `.gitignore`.

Running the bundled demos writes feedback JSON into `demo/fixture/.pairtex/feedback/`. That is per-run local output rather than fixture content, so it should not sit in the working tree as untracked noise.

## Notes

- `demo/fixture/.pairtex/` is currently the only such directory in the repo (4 feedback JSON files from a demo run).
- No `.pairtex` file is tracked today, so ignoring the directory outright cannot drop anything from version control.
- The pattern is unanchored on purpose: PairTeX writes `.pairtex/` into whatever project it targets, so this covers the other demo projects too if they are ever run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtWRX5q9dRRL2eiH4okG1U