### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+
+updates:
+  # ci.yml pins actions to exact tags, which is reproducible but goes stale
+  # silently. Dependabot is what turns those pins back into a live decision.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+    # One PR for all actions rather than one per action. CI runs the whole
+    # matrix on it, so a grouped bump is still fully checked.
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+# No Python ecosystem entry on purpose: pyproject.toml declares an empty
+# dependency list, so there is nothing for Dependabot to bump. Add one here if
+# PairTeX ever takes a real dependency.


### PR DESCRIPTION
`ci.yml` pins `actions/checkout` and `astral-sh/setup-uv` to exact tags. That is reproducible, but nothing would ever tell us a pin has gone stale. The `setup-uv@v10` failure on the previous PR is the cheap version of that problem: an action reference can be wrong in a way only a run reveals.

## Choices

- **Monthly**, not weekly. Two pinned actions do not justify more noise than that.
- **Grouped into a single PR** rather than one per action. CI runs the full 3.11-3.14 matrix on it either way, so a grouped bump is still fully checked.
- **No Python ecosystem entry.** `pyproject.toml` declares `dependencies = []`, so Dependabot would have nothing to bump. The file says so, for whoever adds the first real dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtWRX5q9dRRL2eiH4okG1U