### PR TITLE
Add a release checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ The version is written in exactly one place, `pyproject.toml`.
 `tests/test_version.py` fails if the two ever drift, so a release is one edit
 plus a test run rather than a hunt through the tree.
 
+Before tagging a release, work through
+[`docs/release-checklist.md`](docs/release-checklist.md). It exists because a
+published tag should never have to move.
+
 ## Project boundary
 
 PairTeX is a clean drop-in layer, not an IDE or Overleaf replacement. It does

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,6 +205,10 @@ uv run python -m unittest discover -s tests -t .
 `pairtex.__version__`，`tests/test_version.py` 盯着这两个，一对不上就直接挂。所以
 发版是改一个数再跑一遍测试，不会出现 tag 写一个版本、工具自己报另一个版本这种事。
 
+打 tag 之前先过一遍
+[`docs/release-checklist.md`](docs/release-checklist.md)。这份清单存在的理由就一
+条：已经发布出去的 tag 不该再动。
+
 ## 项目边界
 
 PairTeX 是一个干净的、插上就走的层，不是 IDE，也不是 Overleaf 的替代品。它不提供

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,71 @@
+# Release checklist
+
+Run this before creating a tag.
+
+The point is to find gaps while the tag does not yet exist. Once a tag is
+published, moving it silently diverges for anyone who already cloned the
+repository, because git does not update existing tags by default. If something
+turns up after a release, ship a patch version rather than retagging.
+
+## Checks
+
+### 1. Nothing is missing from the tree
+
+```sh
+git status --short
+```
+
+Untracked files are the point of this check, not noise. Decide for each one
+whether it belongs in the release, in `.gitignore`, or nowhere.
+
+### 2. Tests pass on the exact commit being tagged
+
+```sh
+uv run python -m unittest discover -s tests -t .
+```
+
+### 3. CI is green on that commit
+
+```sh
+gh run list --branch main --workflow ci.yml --limit 1
+```
+
+Wait for `completed / success`. Do not tag a commit CI has not verified.
+
+### 4. The version is the one you mean to publish
+
+```sh
+grep '^version' pyproject.toml
+python3 pairtex.py --version
+python3 pairtex_render.py --version
+```
+
+`tests/test_version.py` already fails on drift between these, so check 2 covers
+consistency. What this step adds is a human confirming the number itself.
+
+### 5. Licensing is consistent
+
+```sh
+ls LICENSE
+grep -rn '^license:' skills/
+```
+
+Every license declared anywhere in the tree must agree with `LICENSE`.
+
+### 6. Both READMEs describe current behavior
+
+`README.md` and `README.zh-CN.md`. The commands, flags, and paths they show
+should still be the ones the code accepts, and the two must not have drifted
+apart.
+
+## Tagging
+
+```sh
+git tag -a <version> -m "PairTeX <version>"
+git push origin <version>
+gh release create <version> --title "<version>" --verify-tag --notes-file <notes>
+```
+
+## If a gap appears after publishing
+
+Ship a patch version. Do not delete and recreate a published tag.


### PR DESCRIPTION
`0.1.0` was tagged three times in one session. The first tag had no `pyproject.toml` and no declared version; the second had no CI. Both gaps surfaced only after the release was already public, and each fix meant deleting and recreating a published tag.

That was survivable only because nobody had pulled the repository yet. Git does not update existing tags by default, so a moved tag silently diverges for anyone who already cloned. The durable fix is to find the gaps while the tag does not exist yet.

## What it covers

Six checks, each paired with the command that answers it:

1. Nothing missing from the tree (`git status --short`) — untracked files are the point of the check, not noise.
2. Tests green on the exact commit being tagged.
3. CI green on that commit. Do not tag what CI has not verified.
4. The version is the one you mean to publish. `tests/test_version.py` already catches drift; this step is a human confirming the number.
5. Licensing consistent across the tree — the check that would have caught `SKILL.md` declaring MIT while the repo had no LICENSE.
6. Both READMEs still accurate and not drifted apart.

Then the tagging commands, and the rule that a gap found after publishing becomes a patch version rather than a retag.

Written in English to match the rest of `docs/`. Linked from the Development section of both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WtWRX5q9dRRL2eiH4okG1U