### PR TITLE
Fix interactions for rendered prose containing inline math

### DIFF
--- a/pairtex/static/app.js
+++ b/pairtex/static/app.js
@@ -196,7 +196,25 @@ function activatePaperPanel(target, selectedTab = null) {
 function markFallbackEditableText() {
   paperQueryAll("p").forEach((block) => {
     if (block.dataset.editable || block.closest(".thebibliography, figure, figcaption, .tableofcontents")) return;
-    if (block.querySelector("img, table, math, svg")) return;
+    if (block.querySelector("img, table, svg")) return;
+    if (block.querySelector("math, [data-editable=\"math\"]")) {
+      // Keep formulas independent while allowing surrounding prose to be edited.
+      const walker = document.createTreeWalker(block, NodeFilter.SHOW_TEXT);
+      const nodes = [];
+      while (walker.nextNode()) {
+        const node = walker.currentNode;
+        if (node.textContent.trim() && !node.parentElement.closest('math, [data-editable="math"], [data-editable="text"]')) nodes.push(node);
+      }
+      nodes.forEach((node) => {
+        const span = document.createElement("span");
+        span.dataset.editable = "text";
+        span.dataset.sourceText = node.textContent.trim();
+        span.dataset.section = block.closest(".paper-panel")?.dataset.sectionName || "";
+        node.replaceWith(span);
+        span.append(node);
+      });
+      return;
+    }
     const text = block.innerText.trim();
     if (!text) return;
     block.dataset.editable = "text";
@@ -241,8 +259,12 @@ function renderedOffset(entry) {
   return offset >= 0 ? offset : Number.MAX_SAFE_INTEGER;
 }
 
+function manuscriptSelection() {
+  return state.paperShadow?.getSelection?.() || window.getSelection();
+}
+
 function selectedAnchor() {
-  const selection = window.getSelection();
+  const selection = manuscriptSelection();
   if (!selection || selection.isCollapsed || !selection.toString().trim()) return null;
   const node = selection.anchorNode?.parentElement?.closest("[data-source-file], [data-editable=\"text\"]");
   if (!node) return null;
@@ -268,7 +290,7 @@ function showTools() {
     return;
   }
   const anchor = selectedAnchor();
-  const selection = window.getSelection();
+  const selection = manuscriptSelection();
   if (!anchor || !selection?.rangeCount) {
     $("#selection-tools").hidden = true;
     return;
@@ -713,6 +735,8 @@ async function refreshView() {
   const host = $("#paper");
   if (!state.paperShadow) {
     state.paperShadow = host.attachShadow({ mode: "open" });
+    state.paperShadow.addEventListener("mouseup", showTools);
+    state.paperShadow.addEventListener("keyup", showTools);
     state.paperShadow.addEventListener("input", scheduleDirectEdit);
     state.paperShadow.addEventListener("click", (event) => {
       const math = event.target.closest('[data-editable="math"]');
@@ -776,6 +800,7 @@ async function refreshFromServer() {
   button.textContent = "Refreshing…";
   try {
     await refreshView();
+    setMode(state.mode);
   } catch (error) {
     alert(`Could not refresh the manuscript: ${error.message}`);
   } finally {
@@ -789,6 +814,7 @@ async function init() {
   await refreshView();
   setMode("edit");
   document.addEventListener("selectionchange", showTools);
+  $("#selection-tools").addEventListener("mousedown", (event) => event.preventDefault());
   $("#selection-tools").addEventListener("click", (event) => {
     const action = event.target.closest("button")?.dataset.action;
     if (action) openEntryDialog(action === "change" ? "change" : "comment");

--- a/tests/browser-interactions.cjs
+++ b/tests/browser-interactions.cjs
@@ -1,0 +1,60 @@
+// Run with NODE_PATH pointing to an installed Playwright package.
+// PAIRTEX_TEST_HTML optionally exercises a real rendered manuscript.
+const { chromium } = require('playwright');
+const { mkdtempSync, writeFileSync, readdirSync, readFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+const { spawn } = require('node:child_process');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const project = mkdtempSync(join(tmpdir(), 'pairtex-browser-'));
+  const html = process.env.PAIRTEX_TEST_HTML || join(project, 'main.html');
+  writeFileSync(join(project, 'main.tex'), 'Browser regression fixture');
+  if (!process.env.PAIRTEX_TEST_HTML) writeFileSync(html, '<p>Editable prose <span data-source-file="main.tex" data-editable="math" data-math-source="x"><math><mi>x</mi></math></span> after the formula.</p>');
+  const server = spawn(process.env.PYTHON || 'python3', [resolve('pairtex.py'), '--project', project, '--html', html, '--port', '0']);
+  server.stderr.pipe(process.stderr);
+  let browser;
+  try {
+    const url = await new Promise((resolveURL, reject) => {
+      server.stdout.on('data', data => { const match = String(data).match(/http:\/\/[^\s]+/); if (match) resolveURL(match[0]); });
+      server.on('error', reject);
+      server.on('exit', code => reject(new Error(`Server exited: ${code}`)));
+    });
+    browser = await chromium.launch();
+    const page = await browser.newPage();
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.goto(url);
+    const text = page.locator('#paper [data-editable="text"]').filter({visible:true}).first();
+    await text.waitFor();
+    const original = await text.innerText();
+    await text.click();
+    await page.keyboard.press('Home');
+    await page.keyboard.type('TEST ');
+    await page.locator('#save-edits').click();
+    await page.waitForFunction(() => document.querySelector('#entry-count').textContent === '1');
+    await text.evaluate(node => {
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      const selection = window.getSelection();
+      selection.removeAllRanges(); selection.addRange(range);
+      node.dispatchEvent(new MouseEvent('mouseup', {bubbles:true, composed:true}));
+    });
+    await page.locator('[data-action="comment"]').click();
+    await page.locator('#message').fill('Browser regression comment');
+    await page.locator('#save-entry').click();
+    await page.waitForFunction(() => document.querySelector('#entry-count').textContent === '2');
+    await page.reload();
+    await page.waitForFunction(() => document.querySelector('#entry-count').textContent === '2');
+    await page.locator('#refresh-view').click();
+    await page.waitForFunction(() => document.querySelector('#refresh-view').textContent === 'Refresh');
+    assert.equal(await page.locator('#paper [data-editable="text"]').first().getAttribute('contenteditable'), 'true');
+    const entries = readdirSync(join(project,'.pairtex/feedback')).map(file => JSON.parse(readFileSync(join(project,'.pairtex/feedback',file))));
+    assert(entries.some(e => e.kind === 'comment' && e.payload.comment === 'Browser regression comment'));
+    assert(entries.some(e => e.kind === 'change' && e.payload.proposed_content.includes('TEST')));
+    assert.deepEqual(errors, []);
+    if (process.env.PAIRTEX_SCREENSHOT) await page.screenshot({path:process.env.PAIRTEX_SCREENSHOT, fullPage:true});
+    console.log(JSON.stringify({passed:true, project, original:original.slice(0,80), entries:entries.length}));
+  } finally { await browser?.close(); server.kill(); }
+})().catch(error => { console.error(error); process.exitCode=1; });


### PR DESCRIPTION
Rendered prose containing inline MathML was excluded from fallback editing entirely. Opening such a manuscript (including its abstract) therefore left the prose read-only. Separately, Refresh replaced the manuscript DOM without restoring the active interaction mode.

This change makes prose text nodes around formulas independently editable, keeps formula markup outside those editing regions, restores mode after Refresh, and reads shadow-root selections where supported. The toolbar also preserves selection on mousedown.

Validation: all 4 Python tests pass. A new Playwright browser regression types into prose containing inline math, saves an accepted edit, selects prose and clicks Comment, saves a comment, reloads and checks both persisted JSON entries, and checks Edit state after Refresh. This passed both on a minimal mixed-math fixture and the user's actual make4ht manuscript with its CSS and figure resources loaded. Test feedback was written to isolated temporary projects, not the real manuscript.

Review: checked that canonical TeX remains untouched and formula nodes are not made contenteditable by the new fallback. Browser coverage currently uses Chromium; other engines are not claimed as verified. The test can be run with `NODE_PATH` pointing to an installed Playwright package and `PYTHON` pointing to a supported Python, using `node tests/browser-interactions.cjs`. Set `PAIRTEX_TEST_HTML` to test an existing projection.

Correction to #10: the earlier issue report claimed successful browser validation before that had actually been performed. Those claims were premature. The now-observed failures are missing editable prose around MathML and mode loss on Refresh; the toolbar change is defensive, not a proven explanation of every reported symptom.

Closes #10.
