### PR TITLE
Fix Math input errors and remove Edit frames

### DIFF
--- a/pairtex/static/app.js
+++ b/pairtex/static/app.js
@@ -512,6 +512,28 @@ async function typesetMath(element) {
   }
 }
 
+async function renderSourceMath() {
+  if (!window.MathJax?.startup?.promise) return;
+  await window.MathJax.startup.promise;
+  if (!window.MathJax.tex2mmlPromise) return;
+  const root = state.paperRoot;
+  for (const block of root.querySelectorAll('[data-math-source]')) {
+    const target = block.querySelector('.math-render');
+    if (!target || state.mathDirty.has(block)) continue;
+    const display = target.querySelector('math')?.getAttribute('display') === 'block';
+    const markup = await window.MathJax.tex2mmlPromise(block.dataset.mathSource, { display });
+    if (root !== state.paperRoot) return;
+    if (state.mathDirty.has(block)) continue;
+    const parsed = new DOMParser().parseFromString(markup, 'application/xml');
+    // A project's custom TeX macros may be unknown to MathJax. Preserve its
+    // renderer output rather than replacing it with an error in that case.
+    if (parsed.querySelector('merror, parsererror')) continue;
+    // Native MathML also works inside the paper's shadow root without
+    // depending on MathJax's document-level CHTML stylesheets.
+    target.replaceChildren(document.importNode(parsed.documentElement, true));
+  }
+}
+
 function renderMathPreview(source) {
   const preview = $("#math-preview");
   preview.textContent = `\\[${source}\\]`;
@@ -783,9 +805,7 @@ async function refreshView() {
   organizePaper();
   markFallbackEditableText();
   captureEditBaselines();
-  if (window.MathJax?.startup?.promise) {
-    window.MathJax.startup.promise.then(() => typesetMath(state.paperRoot)).catch(() => {});
-  }
+  await renderSourceMath();
   $("#version-status").textContent = state.project.worktree_dirty ? "Local changes" : "Git version tracked";
   renderEntries(state.project.entries);
   decoratePaper(state.project.entries);
@@ -812,6 +832,7 @@ async function refreshFromServer() {
 async function init() {
   initThemeControls();
   await refreshView();
+  window.addEventListener('load', () => renderSourceMath().catch(console.error), { once: true });
   setMode("edit");
   document.addEventListener("selectionchange", showTools);
   $("#selection-tools").addEventListener("mousedown", (event) => event.preventDefault());

--- a/pairtex/static/style.css
+++ b/pairtex/static/style.css
@@ -61,9 +61,7 @@ button { cursor: pointer; }
 .paper { width: 100%; max-width: none; min-width: 0; }
 .paper-panel { display: none; }
 .paper-panel.is-active { display: block; }
-.paper.is-editing { padding: 20px 18px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
-.paper.is-editing [data-source-file] { outline: 1px dashed transparent; outline-offset: 7px; }
-.paper.is-editing [data-source-file]:hover, .paper.is-editing [data-source-file]:focus-within { outline-color: var(--border-hi); }
+.paper.is-editing [contenteditable="true"]:focus { outline: none; }
 .paper h1, .paper h2, .paper h3 { line-height: 1.25; letter-spacing: -.02em; }
 .paper h1 { font-size: 38px; }
 .paper h2 { margin-top: 2em; font-size: 25px; }

--- a/tests/browser-interactions.cjs
+++ b/tests/browser-interactions.cjs
@@ -11,7 +11,7 @@ const assert = require('node:assert/strict');
   const project = mkdtempSync(join(tmpdir(), 'pairtex-browser-'));
   const html = process.env.PAIRTEX_TEST_HTML || join(project, 'main.html');
   writeFileSync(join(project, 'main.tex'), 'Browser regression fixture');
-  if (!process.env.PAIRTEX_TEST_HTML) writeFileSync(html, '<p>Editable prose <span data-source-file="main.tex" data-editable="math" data-math-source="x"><math><mi>x</mi></math></span> after the formula.</p>');
+  if (!process.env.PAIRTEX_TEST_HTML) writeFileSync(html, '<p>Editable prose <span data-source-file="main.tex" data-editable="math" data-math-source="x"><span class="math-render"><math>x</math></span></span> after the formula.</p>');
   const server = spawn(process.env.PYTHON || 'python3', [resolve('pairtex.py'), '--project', project, '--html', html, '--port', '0']);
   server.stderr.pipe(process.stderr);
   let browser;
@@ -28,8 +28,29 @@ const assert = require('node:assert/strict');
     await page.goto(url);
     const text = page.locator('#paper [data-editable="text"]').filter({visible:true}).first();
     await text.waitFor();
+    // Wait explicitly: otherwise a fast interaction test can finish before
+    // the asynchronous MathJax script exposes malformed renderer MathML.
+    await page.waitForFunction(() => Boolean(window.MathJax?.tex2mmlPromise));
+    const math = await page.evaluate(async () => {
+      await renderSourceMath();
+      const root = document.querySelector('#paper').shadowRoot;
+      return {
+        count: root.querySelectorAll('math').length,
+        errors: root.querySelectorAll('merror, mjx-merror, parsererror').length,
+        bareTokens: [...root.querySelectorAll('math, mrow')].some(node =>
+          [...node.childNodes].some(child => child.nodeType === Node.TEXT_NODE && child.textContent.trim())),
+      };
+    });
+    assert(math.count > 0);
+    assert.equal(math.errors, 0);
+    assert.equal(math.bareTokens, false);
     const original = await text.innerText();
     await text.click();
+    assert.deepEqual(await text.evaluate(node => ({
+      outline: getComputedStyle(node).outlineStyle,
+      border: getComputedStyle(node.closest('.paper')).borderTopWidth,
+      editable: node.isContentEditable,
+    })), { outline: 'none', border: '0px', editable: true });
     await page.keyboard.press('Home');
     await page.keyboard.type('TEST ');
     await page.locator('#save-edits').click();


### PR DESCRIPTION
Some make4ht formulas contain bare text directly inside MathML `math`/`mrow` elements. When the asynchronous MathJax loader finishes early enough, its MathML input processor turns these into “Math input error” (60 failures in the reported manuscript). The previous fast browser test could finish before this happened.

Rebuild annotated formulas from their stored TeX into native MathML, which also avoids document-level CHTML stylesheet dependencies inside the manuscript shadow root. Handle both loader timing orders, preserve renderer output for unsupported custom macros, and avoid overwriting pending user math edits or a replaced projection.

Also remove the Edit-mode container frame and editable-text focus outline, as requested by the user, without removing contenteditable behavior.

Validation and review:
- All four Python tests pass; JS syntax and diff checks pass.
- Extended Chromium regression explicitly waits for MathJax and checks no bare MathML tokens or error nodes, no Edit frame/focus outline, and retained editing capability.
- Both the deliberately malformed mixed-math fixture and the actual 92-formula manuscript pass editing, comment creation, JSON persistence, reload, and Refresh checks. Test feedback uses temporary projects.
- Reviewed asynchronous replacement guards and fallback behavior for TeX macros unknown to MathJax. No canonical manuscript changes; no additional runtime dependency.

Browser coverage is Chromium. This PR does not claim cross-browser testing or provide offline MathJax distribution.
