### PR TITLE
Prepare PairTeX 0.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ uv sync
 uv run python -m unittest discover -s tests -t .
 ```
 
-The version is written in exactly one place, `pyproject.toml`.
-`pairtex.py --version` reports it through `pairtex.__version__`, and
-`tests/test_version.py` fails if the two ever drift, so a release is one edit
-plus a test run rather than a hunt through the tree.
+`pyproject.toml` declares the release version. When preparing a release, update
+that version and `__version__` in `pairtex.py`, then run `uv lock` to refresh
+`uv.lock`. Both entry points report `pairtex.__version__`;
+`tests/test_version.py` fails if it differs from the declared version.
 
 Before tagging a release, work through
 [`docs/release-checklist.md`](docs/release-checklist.md). It exists because a

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,9 +201,9 @@ uv sync
 uv run python -m unittest discover -s tests -t .
 ```
 
-版本号只写在 `pyproject.toml` 这一个地方。`pairtex.py --version` 报的是
-`pairtex.__version__`，`tests/test_version.py` 盯着这两个，一对不上就直接挂。所以
-发版是改一个数再跑一遍测试，不会出现 tag 写一个版本、工具自己报另一个版本这种事。
+`pyproject.toml` 声明发布版本。准备发版时，需要同步更新它和 `pairtex.py` 中的
+`__version__`，再运行 `uv lock` 更新 `uv.lock`。两个命令行入口都通过
+`pairtex.__version__` 报告版本；`tests/test_version.py` 会检查它是否与声明的版本一致。
 
 打 tag 之前先过一遍
 [`docs/release-checklist.md`](docs/release-checklist.md)。这份清单存在的理由就一

--- a/pairtex.py
+++ b/pairtex.py
@@ -24,7 +24,7 @@ from pairtex_validation import validate_rendered_html
 
 # Single source of truth is pyproject.toml; tests/test_version.py fails if the
 # two drift apart.
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 ROOT = Path(__file__).resolve().parent
 STATIC_DIR = ROOT / "pairtex" / "static"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pairtex"
-version = "0.1.0"
+version = "0.1.1"
 description = "A local, Git-native review and feedback layer for existing LaTeX projects."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "pairtex"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }


### PR DESCRIPTION
Prepare PairTeX 0.1.1 for the reviewed fixes in #11, #12, and #17. Update pyproject.toml, the runtime version, and uv.lock together so both CLI entry points report 0.1.1. Correct the English and Chinese README release instructions to describe the actual version update steps.

Validation: all 16 Python tests pass on Python 3.11; both CLI version commands report 0.1.1; uv lock --check and git diff --check pass. The release tag will be created only after this PR and the final main commit pass CI, following docs/release-checklist.md.
