### PR TITLE
Fix duplicate labels in live formula previews

### DIFF
--- a/docs/renderer-adapters.md
+++ b/docs/renderer-adapters.md
@@ -76,8 +76,19 @@ installation and a browser, with `NODE_PATH` pointing to its `node_modules`:
 ```sh
 node tests/browser-regressions.cjs
 node tests/browser-interactions.cjs
+node tests/browser-math-labels.cjs
 ```
 
 Set `PAIRTEX_BROWSER_CHANNEL=chrome` to use installed Chrome. The regression suite
 intercepts MathJax loading to test success, delay, and failure deterministically;
 the interaction suite also exercises the real CDN converter.
+
+The math-label browser suite uses the real MathJax 3 CDN and verifies labelled
+and unlabelled previews, reopening, repeated input, document references, and
+complete labels in saved feedback. Draft previews and edited formula rendering
+use a fresh TeX input instance and a separate MathDocument for each conversion.
+The draft instance copies document references, treats label commands as
+presentation-only, and never resets the document's label state. Complete source
+(including labels) remains in the editor and feedback. This integration uses the
+constructors and conversion machinery exposed by the MathJax 3 startup component;
+rerun the browser suites when changing the MathJax major version.

--- a/pairtex/static/app.js
+++ b/pairtex/static/app.js
@@ -514,10 +514,38 @@ function scheduleDirectEdit(event) {
   updateSaveButton();
 }
 
-async function typesetMath(element) {
-  if (window.MathJax?.typesetPromise) {
-    await window.MathJax.typesetPromise([element]);
-  }
+// Each draft conversion owns its TeX state. Never reset the paper's labels or
+// redefine commands in its input jax: MathJax 3 can retain macro definitions.
+let draftMathQueue = Promise.resolve();
+let mathPreviewRevision = 0;
+
+function renderDraftMath(source, display = true) {
+  const task = draftMathQueue.then(async () => {
+    const mathjax = window.MathJax;
+    if (!mathjax?.startup?.promise) return null;
+    await mathjax.startup.promise;
+    const startup = mathjax.startup;
+    const original = startup.document?.inputJax.find(jax => jax.name === "TeX");
+    if (!original || !startup.handler || !mathjax._?.mathjax?.mathjax) return null;
+    const input = new original.constructor({
+      ...mathjax.config.tex,
+      packages: [...original.options.packages],
+      // Labels belong to canonical equations, not their transient previews.
+      macros: {...mathjax.config.tex.macros, label: ["", 1]},
+    });
+    const doc = startup.handler.create(document.implementation.createHTMLDocument(""), {InputJax: [input]});
+    input.parseOptions.tags.allLabels = Object.fromEntries(
+      Object.entries(original.parseOptions.tags.allLabels).map(([key, value]) => [key, {...value}]),
+    );
+    const markup = await mathjax._.mathjax.mathjax.handleRetriesFor(() =>
+      startup.toMML(doc.convert(source, {display, end: mathjax._.core.MathItem.STATE.CONVERT})),
+    );
+    const parsed = new DOMParser().parseFromString(markup, "application/xml");
+    if (parsed.querySelector("parsererror")) throw new Error("Could not render formula preview");
+    return document.importNode(parsed.documentElement, true);
+  });
+  draftMathQueue = task.catch(() => {});
+  return task;
 }
 
 async function renderSourceMath() {
@@ -555,10 +583,21 @@ async function renderSourceMath() {
   }
 }
 
-function renderMathPreview(source) {
+async function renderMathPreview(source) {
   const preview = $("#math-preview");
-  preview.textContent = `\\[${source}\\]`;
-  typesetMath(preview).catch(() => {});
+  const revision = ++mathPreviewRevision;
+  preview.textContent = source;
+  preview.dataset.renderState = "pending";
+  try {
+    const math = await renderDraftMath(source);
+    if (revision !== mathPreviewRevision) return;
+    if (math) preview.replaceChildren(math);
+    preview.dataset.renderState = math ? "ready" : "source";
+  } catch (error) {
+    if (revision !== mathPreviewRevision) return;
+    preview.textContent = `${source} — Preview unavailable: ${error.message}`;
+    preview.dataset.renderState = "error";
+  }
 }
 
 function openMathEditor(block) {
@@ -584,9 +623,19 @@ async function saveMathEdit(event) {
     state.mathBlock = null;
     return;
   }
+  const revision = mathPreviewRevision;
+  const target = block.querySelector(".math-render");
+  const display = target.querySelector("math")?.getAttribute("display") === "block";
+  let math = null;
+  try {
+    math = await renderDraftMath(source, display);
+  } catch {
+    // Keep the complete draft readable and saveable when conversion fails.
+  }
+  if (state.mathBlock !== block || revision !== mathPreviewRevision || !block.isConnected) return;
   block.dataset.mathSource = source;
-  block.querySelector(".math-render").textContent = `\\[${source}\\]`;
-  await typesetMath(block.querySelector(".math-render"));
+  if (math) target.replaceChildren(math);
+  else target.textContent = source;
   state.mathDirty.add(block);
   updateSaveButton();
   $("#math-dialog").close();
@@ -609,8 +658,8 @@ async function persistMathEdit(block) {
       line_start_hint: Number(block.dataset.sourceLine || 0) || null,
       line_end_hint: Number(block.dataset.sourceLineEnd || block.dataset.sourceLine || 0) || null,
       section: (block.dataset.section || "").split("/").filter(Boolean),
-      selected_rendered_text: state.mathBaseline,
-      selected_source_text: state.mathBaseline,
+      selected_rendered_text: state.mathSourceBaselines.get(block) || "",
+      selected_source_text: state.mathSourceBaselines.get(block) || "",
       rendered_offset: 0,
       prefix_context: "",
       suffix_context: "",
@@ -874,6 +923,10 @@ async function init() {
   $("#refresh-view").addEventListener("click", refreshFromServer);
   $("#math-source").addEventListener("input", (event) => renderMathPreview(event.target.value));
   $("#math-form").addEventListener("submit", saveMathEdit);
+  $("#math-dialog").addEventListener("close", () => {
+    ++mathPreviewRevision;
+    state.mathBlock = null;
+  });
   $("#cancel-math").addEventListener("click", () => {
     state.mathBlock = null;
     $("#math-dialog").close();

--- a/tests/browser-math-labels.cjs
+++ b/tests/browser-math-labels.cjs
@@ -1,0 +1,106 @@
+// Requires Playwright via NODE_PATH and a browser; exercises the real MathJax CDN.
+const { chromium } = require('playwright');
+const { mkdtempSync, writeFileSync, readFileSync, readdirSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { join, resolve } = require('node:path');
+const { spawn } = require('node:child_process');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const project = mkdtempSync(join(tmpdir(), 'pairtex-labels-'));
+  const html = join(project, 'main.html');
+  const sources = ['a+b=c', String.raw`a+b=c\label{eq:demo}`, String.raw`x+y=z\label{eq:second}`, String.raw`d=e\tag{17}\label{eq:ref}`];
+  const escape = s => s.replaceAll('&', '&amp;').replaceAll('"', '&quot;');
+  writeFileSync(join(project, 'main.tex'), sources.join('\n'));
+  writeFileSync(html, sources.map((source, i) => `<p><span id="formula-${i}" data-editable="math" data-source-file="main.tex" data-source-line="${i + 1}" data-math-source="${escape(source)}"><span class="math-render"><math display="block"><mi>a</mi><mo>+</mo><mi>b</mi><mo>=</mo><mi>c</mi></math></span></span></p>`).join(''));
+  const server = spawn(process.env.PYTHON || 'python3', [resolve('pairtex.py'), '--project', project, '--html', html, '--port', '0']);
+  let browser;
+  try {
+    const url = await new Promise((res, rej) => {
+      server.stdout.on('data', data => { const match = String(data).match(/http:\/\/[^\s]+/); if (match) res(match[0]); });
+      server.on('error', rej); server.on('exit', code => rej(new Error(`Server exited: ${code}`)));
+    });
+    browser = await chromium.launch(process.env.PAIRTEX_BROWSER_CHANNEL ? {channel: process.env.PAIRTEX_BROWSER_CHANNEL} : {});
+    const page = await browser.newPage();
+    page.setDefaultTimeout(15000);
+    const errors = [];
+    page.on('pageerror', error => errors.push(error.message));
+    await page.goto(url);
+    await page.waitForFunction(() => Boolean(window.MathJax?.tex2mmlPromise));
+    await page.evaluate(() => renderSourceMath());
+    const documentState = () => page.evaluate(async () => {
+      const input = MathJax.startup.document.inputJax.find(jax => jax.name === 'TeX');
+      const reference = await MathJax.tex2mmlPromise(String.raw`\eqref{eq:ref}`);
+      return {labels: input.parseOptions.tags.allLabels, ids: input.parseOptions.tags.allIds, reference};
+    });
+    const before = await documentState();
+    assert(before.reference.includes('17'));
+    assert(!before.reference.includes('merror'));
+    async function previewContains(expected) {
+      await page.waitForFunction(expected => {
+        const preview = document.querySelector('#math-preview');
+        return preview.dataset.renderState === 'ready' && preview.textContent.replace(/\s/g, '').includes(expected);
+      }, expected);
+      const failures = await page.locator('#math-preview merror, #math-preview [data-mjx-error]').allTextContents();
+      assert.deepEqual(failures, []);
+      const box = await page.locator('#math-preview math').boundingBox();
+      assert(box.width > 0 && box.height > 0);
+    }
+    for (const index of [0, 1, 1, 2, 3]) {
+      await page.locator(`#paper #formula-${index}`).click();
+      await previewContains(index === 2 ? 'x+y=z' : index === 3 ? 'd=e' : 'a+b=c');
+      assert.equal(await page.locator('#math-source').inputValue(), sources[index]);
+      await page.locator('#cancel-math').click();
+    }
+    assert.deepEqual(await documentState(), before, 'previewing must preserve labels, ids and references');
+    await page.locator('#paper #formula-1').click();
+    for (const n of [2, 3, 4]) {
+      await page.locator('#math-source').fill(String.raw`a+${n}=c\label{eq:demo}`);
+      await previewContains(`a+${n}=c`);
+    }
+    // A preview may read a document reference, but must not add its own label.
+    await page.locator('#math-source').fill(String.raw`\eqref{eq:ref}+q\label{eq:draft}`);
+    await previewContains('(17)+q');
+    assert.deepEqual(await documentState(), before);
+    // Queue several real conversions in one turn: only the newest may update the UI.
+    await page.evaluate(() => {
+      for (const n of [5, 6, 7]) {
+        const source = document.querySelector('#math-source');
+        source.value = `a+${n}=c\\label{eq:demo}`;
+        source.dispatchEvent(new Event('input', {bubbles: true}));
+      }
+    });
+    await previewContains('a+7=c');
+    await page.locator('#math-form button[value="save"]').click();
+    await page.locator('#math-dialog').waitFor({state: 'hidden'});
+    assert.equal(await page.locator('#paper #formula-1').getAttribute('data-math-source'), String.raw`a+7=c\label{eq:demo}`);
+    assert.equal(await page.locator('#paper #formula-1 merror, #paper #formula-1 [data-mjx-error]').count(), 0);
+    // Edit a second formula before persisting: each anchor needs its own original source.
+    await page.locator('#paper #formula-2').click();
+    await page.locator('#math-source').fill(String.raw`x+2=z\label{eq:second}`);
+    await previewContains('x+2=z');
+    await page.locator('#math-form button[value="save"]').click();
+    await page.locator('#math-dialog').waitFor({state: 'hidden'});
+    await page.locator('#save-edits').click();
+    await page.waitForFunction(() => document.querySelector('#entry-count').textContent === '2');
+    const entries = readdirSync(join(project, '.pairtex/feedback')).map(name => JSON.parse(readFileSync(join(project, '.pairtex/feedback', name))));
+    for (const [index, proposed] of [[1, String.raw`a+7=c\label{eq:demo}`], [2, String.raw`x+2=z\label{eq:second}`]]) {
+      const entry = entries.find(e => e.anchor.line_start_hint === index + 1);
+      assert.equal(entry.anchor.selected_source_text, sources[index]);
+      assert.equal(entry.payload.proposed_content, proposed);
+    }
+    assert.deepEqual(await documentState(), before);
+    assert.equal(readFileSync(join(project, 'main.tex'), 'utf8'), sources.join('\n'));
+    // Draft-only macro definitions must not have disabled real label handling.
+    assert(await page.evaluate(async () => {
+      await MathJax.tex2mmlPromise(String.raw`r=s\label{eq:after-preview}`);
+      return Boolean(MathJax.startup.document.inputJax.find(jax => jax.name === 'TeX').parseOptions.tags.allLabels['eq:after-preview']);
+    }));
+    assert.deepEqual(errors, []);
+    console.log('PASS: labelled previews, repeated/rapid edits, isolated references, saved labels and per-formula anchors');
+  } finally {
+    await browser?.close(); server.kill();
+    await new Promise(res => server.exitCode !== null ? res() : server.once('exit', res));
+    rmSync(project, {recursive: true, force: true});
+  }
+})().catch(error => {console.error(error); process.exitCode = 1;});

--- a/tests/browser-math-labels.cjs
+++ b/tests/browser-math-labels.cjs
@@ -91,6 +91,55 @@ const assert = require('node:assert/strict');
     }
     assert.deepEqual(await documentState(), before);
     assert.equal(readFileSync(join(project, 'main.tex'), 'utf8'), sources.join('\n'));
+    // Exercise the conversion mechanism beyond the issue's a+b=c example.
+    const variants = await page.evaluate(async () => {
+      const cases = [
+        [String.raw`\frac{x_1}{\sqrt{y}}\label{fraction:any-name}`, false],
+        [String.raw`\begin{aligned}a&=b\label{row:first}\\c&=d\label{row:second}\end{aligned}`, true],
+        [String.raw`\begin{equation}p=q\label{env:equation}\end{equation}`, true],
+        [String.raw`u=v\label {eq:unicode-α}`, true],
+        [String.raw`\newcommand{\pairtexDraftOnly}{q}\pairtexDraftOnly\label{macro:local}`, true],
+      ];
+      const results = [];
+      for (const [source, display] of cases) {
+        const math = await renderDraftMath(source, display);
+        results.push({source, text: math.textContent, display: math.getAttribute('display'),
+          errors: math.querySelectorAll('merror, [data-mjx-error]').length});
+      }
+      const previousMacros = MathJax.config.tex.macros;
+      try {
+        MathJax.config.tex.macros = {...previousMacros, pairtexConfigured: ['#1+#1', 1]};
+        const math = await renderDraftMath(String.raw`\pairtexConfigured{t}\label{macro:configured}`);
+        results.push({source: 'configured macro', text: math.textContent,
+          errors: math.querySelectorAll('merror, [data-mjx-error]').length});
+      } finally {
+        if (previousMacros === undefined) delete MathJax.config.tex.macros;
+        else MathJax.config.tex.macros = previousMacros;
+      }
+      // A failed conversion must not poison subsequent queued work.
+      const runtime = MathJax._.mathjax.mathjax;
+      const retry = runtime.handleRetriesFor;
+      let rejected = false;
+      try {
+        runtime.handleRetriesFor = () => Promise.reject(new Error('Synthetic conversion failure'));
+        await renderDraftMath('x');
+      } catch { rejected = true; }
+      finally { runtime.handleRetriesFor = retry; }
+      const recovered = await renderDraftMath(String.raw`h=k\label{queue:recovered}`);
+      return {results, rejected, recovered: recovered.textContent,
+        recoveredErrors: recovered.querySelectorAll('merror, [data-mjx-error]').length};
+    });
+    for (const result of variants.results) {
+      assert.equal(result.errors, 0, result.source);
+      assert(result.text.trim(), result.source);
+    }
+    assert.notEqual(variants.results[0].display, 'block');
+    assert.equal(variants.results[1].display, 'block');
+    assert.equal(variants.results.at(-1).text.replace(/\s/g, ''), 't+t');
+    assert(variants.rejected);
+    assert.equal(variants.recovered.replace(/\s/g, ''), 'h=k');
+    assert.equal(variants.recoveredErrors, 0);
+    assert.deepEqual(await documentState(), before);
     // Draft-only macro definitions must not have disabled real label handling.
     assert(await page.evaluate(async () => {
       await MathJax.tex2mmlPromise(String.raw`r=s\label{eq:after-preview}`);


### PR DESCRIPTION
Opening a formula containing `\label{eq:demo}` could show “Label 'eq:demo' multiply defined” because the paper and live preview registered the same equation in shared MathJax state. Draft previews and edited-formula rendering now use a fresh TeX input instance and separate MathDocument, copy existing document references, and suppress label registration only in that draft instance. Editor text and saved feedback retain the complete source, including labels.

Async preview results only update the current draft. Saving multiple formula edits also uses each formula's own original source for its feedback anchor, rather than the last-opened editor's baseline.

Validation:
- The new real-CDN browser regression reproduces the duplicate-label failure on 0.1.1 and passes with this fix.
- It checks labelled/unlabelled equations, reopening, repeated and rapid input, multiple labels, visible preview content and error nodes, unchanged document label/ID/reference state, saved labels, and per-formula source anchors. Canonical source remains unchanged.
- The label suite additionally covers inline fractions/roots, aligned and equation environments, label whitespace/Unicode, local and configured macros, and recovery after a rejected conversion.
- All three Playwright suites pass in Chromium, including existing offline/delayed loading and edit/comment/refresh regressions.
- All 16 Python tests, JavaScript syntax checks, and git diff whitespace checks pass.

The isolated conversion uses MathJax 3's exposed startup constructors and conversion machinery; the browser regression should be rerun when upgrading MathJax. Browser suites use a separately installed Playwright and are documented in docs/renderer-adapters.md; the existing GitHub CI covers the Python matrix.

Fixes #19
